### PR TITLE
Connect chat to Notion and ChatGPT APIs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+# Rename this file to .env and fill in your credentials
+OPENAI_API_KEY=
+NOTION_TOKEN=
+NOTION_DATABASE_ID=
+API_PORT=3001

--- a/README.md
+++ b/README.md
@@ -71,3 +71,22 @@ Yes, you can!
 To connect a domain, navigate to Project > Settings > Domains and click Connect Domain.
 
 Read more here: [Setting up a custom domain](https://docs.lovable.dev/tips-tricks/custom-domain#step-by-step-guide)
+
+## API configuration
+
+This project includes a simple Node server that connects with the Notion and OpenAI APIs.
+Copy `.env.example` to `.env` and provide your credentials:
+
+```
+OPENAI_API_KEY=<your openai key>
+NOTION_TOKEN=<your notion token>
+NOTION_DATABASE_ID=<your database id>
+```
+
+Start the API server with:
+
+```
+npm run server
+```
+
+The frontend will send chat messages to `/api/chat` to fetch or create tasks using these APIs.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server.js"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.9.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,157 @@
+// Simple Node server for ChatGPT and Notion integration
+import http from 'http';
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const NOTION_TOKEN = process.env.NOTION_TOKEN;
+const NOTION_DATABASE_ID = process.env.NOTION_DATABASE_ID;
+
+async function getRequestBody(req) {
+  return new Promise((resolve, reject) => {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk.toString();
+    });
+    req.on('end', () => {
+      try {
+        resolve(JSON.parse(body));
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
+async function getTasksFromNotion() {
+  const res = await fetch(`https://api.notion.com/v1/databases/${NOTION_DATABASE_ID}/query`, {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${NOTION_TOKEN}`,
+      'Content-Type': 'application/json',
+      'Notion-Version': '2022-06-28'
+    },
+    body: JSON.stringify({})
+  });
+  const data = await res.json();
+  return data.results.map(page => ({
+    id: page.id,
+    title: page.properties.Name?.title?.[0]?.plain_text || '',
+    status: page.properties.Status?.select?.name || '',
+    priority: page.properties.Priority?.select?.name || ''
+  }));
+}
+
+async function createTaskInNotion(title, description = '') {
+  const res = await fetch('https://api.notion.com/v1/pages', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${NOTION_TOKEN}`,
+      'Content-Type': 'application/json',
+      'Notion-Version': '2022-06-28'
+    },
+    body: JSON.stringify({
+      parent: { database_id: NOTION_DATABASE_ID },
+      properties: {
+        Name: {
+          title: [{ text: { content: title } }]
+        },
+        Description: description ? {
+          rich_text: [{ text: { content: description } }]
+        } : undefined
+      }
+    })
+  });
+  const data = await res.json();
+  return {
+    id: data.id,
+    title,
+    description
+  };
+}
+
+async function callOpenAI(messages, functions = []) {
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${OPENAI_API_KEY}`
+    },
+    body: JSON.stringify({
+      model: 'gpt-3.5-turbo-0613',
+      messages,
+      functions
+    })
+  });
+  return res.json();
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method === 'POST' && req.url === '/api/chat') {
+    try {
+      const { messages } = await getRequestBody(req);
+      const formatted = messages.map(m => ({
+        role: m.sender === 'user' ? 'user' : 'assistant',
+        content: m.text
+      }));
+      const systemMessage = {
+        role: 'system',
+        content: 'You are a planning assistant that manages tasks in Notion. Use the available functions to fetch or create tasks.'
+      };
+      const functions = [
+        {
+          name: 'getTasks',
+          description: 'Get current tasks from Notion',
+          parameters: { type: 'object', properties: {} }
+        },
+        {
+          name: 'createTask',
+          description: 'Create a new task in Notion',
+          parameters: {
+            type: 'object',
+            properties: {
+              title: { type: 'string' },
+              description: { type: 'string' }
+            },
+            required: ['title']
+          }
+        }
+      ];
+
+      let aiResponse = await callOpenAI([systemMessage, ...formatted], functions);
+      const choice = aiResponse.choices[0].message;
+
+      if (choice.function_call) {
+        let result;
+        if (choice.function_call.name === 'getTasks') {
+          result = await getTasksFromNotion();
+        }
+        if (choice.function_call.name === 'createTask') {
+          const args = JSON.parse(choice.function_call.arguments || '{}');
+          result = await createTaskInNotion(args.title, args.description);
+        }
+        const followUp = await callOpenAI([
+          systemMessage,
+          ...formatted,
+          choice,
+          { role: 'function', name: choice.function_call.name, content: JSON.stringify(result) }
+        ]);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ response: followUp.choices[0].message.content }));
+        return;
+      }
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ response: choice.content }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = process.env.API_PORT || 3001;
+server.listen(PORT, () => {
+  console.log('API server listening on port', PORT);
+});
+

--- a/src/components/FloatingChat.tsx
+++ b/src/components/FloatingChat.tsx
@@ -22,28 +22,42 @@ export const FloatingChat = () => {
   const [messages, setMessages] = useState<ChatMessage[]>(initialMessages);
   const [inputValue, setInputValue] = useState('');
 
-  const handleSendMessage = () => {
-    if (inputValue.trim()) {
-      const userMessage: ChatMessage = {
-        id: Date.now().toString(),
-        text: inputValue,
-        sender: 'user',
+  const handleSendMessage = async () => {
+    if (!inputValue.trim()) return;
+
+    const userMessage: ChatMessage = {
+      id: Date.now().toString(),
+      text: inputValue,
+      sender: 'user',
+      timestamp: new Date(),
+    };
+
+    const updatedMessages = [...messages, userMessage];
+    setMessages(updatedMessages);
+    setInputValue('');
+
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ messages: updatedMessages }),
+      });
+      const data = await res.json();
+      const aiResponse: ChatMessage = {
+        id: (Date.now() + 1).toString(),
+        text: data.response || 'Hubo un problema al obtener respuesta.',
+        sender: 'ai',
         timestamp: new Date(),
       };
-
-      setMessages(prev => [...prev, userMessage]);
-      setInputValue('');
-
-      // Simular respuesta del AI
-      setTimeout(() => {
-        const aiResponse: ChatMessage = {
-          id: (Date.now() + 1).toString(),
-          text: `Entiendo que quieres: "${inputValue}". Te puedo ayudar a crear tareas, organizarlas por prioridad, o darte sugerencias para mejorar tu productividad. ¿Qué prefieres?`,
-          sender: 'ai',
-          timestamp: new Date(),
-        };
-        setMessages(prev => [...prev, aiResponse]);
-      }, 1000);
+      setMessages(prev => [...prev, aiResponse]);
+    } catch {
+      const errorMessage: ChatMessage = {
+        id: (Date.now() + 1).toString(),
+        text: 'No se pudo contactar al servidor.',
+        sender: 'ai',
+        timestamp: new Date(),
+      };
+      setMessages(prev => [...prev, errorMessage]);
     }
   };
 


### PR DESCRIPTION
## Summary
- integrate a small Node API server with OpenAI and Notion
- call this API from the floating chat widget
- document API usage and environment variables

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bbe8444a4832d8eabc623412d8879