### PR TITLE
Add Notion block renderer component

### DIFF
--- a/src/components/NotionRenderer.tsx
+++ b/src/components/NotionRenderer.tsx
@@ -1,0 +1,67 @@
+import { NotionBlock } from '@/types'
+
+interface NotionRendererProps {
+  blocks: NotionBlock[]
+}
+
+function extractText(block: any): string {
+  const rich = block?.rich_text || []
+  return rich.map((t: any) => t.plain_text).join('')
+}
+
+export const NotionRenderer = ({ blocks }: NotionRendererProps) => {
+  return (
+    <div className="space-y-2">
+      {blocks.map((block) => {
+        const { id, type } = block
+        switch (type) {
+          case 'heading_1':
+            return (
+              <h1 key={id} className="text-2xl font-bold">
+                {extractText(block.heading_1)}
+              </h1>
+            )
+          case 'heading_2':
+            return (
+              <h2 key={id} className="text-xl font-semibold">
+                {extractText(block.heading_2)}
+              </h2>
+            )
+          case 'heading_3':
+            return (
+              <h3 key={id} className="text-lg font-semibold">
+                {extractText(block.heading_3)}
+              </h3>
+            )
+          case 'paragraph':
+            return (
+              <p key={id} className="text-base">
+                {extractText(block.paragraph)}
+              </p>
+            )
+          case 'to_do':
+            return (
+              <label key={id} className="flex items-center gap-2">
+                <input type="checkbox" disabled checked={block.to_do?.checked} />
+                <span>{extractText(block.to_do)}</span>
+              </label>
+            )
+          case 'bulleted_list_item':
+            return (
+              <ul key={id} className="list-disc ml-6">
+                <li>{extractText(block.bulleted_list_item)}</li>
+              </ul>
+            )
+          case 'numbered_list_item':
+            return (
+              <ol key={id} className="list-decimal ml-6">
+                <li>{extractText(block.numbered_list_item)}</li>
+              </ol>
+            )
+          default:
+            return null
+        }
+      })}
+    </div>
+  )
+}

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -23,3 +23,19 @@ export async function getTasksFromNotion() {
     priority: page.properties.Priority?.select?.name || '',
   }))
 }
+
+export async function getPageBlocks(pageId: string) {
+  const NOTION_TOKEN = import.meta.env.NOTION_TOKEN
+  const res = await fetch(
+    `https://api.notion.com/v1/blocks/${pageId}/children`,
+    {
+      headers: {
+        Authorization: `Bearer ${NOTION_TOKEN}`,
+        'Content-Type': 'application/json',
+        'Notion-Version': '2022-06-28',
+      },
+    }
+  )
+  const data = await res.json()
+  return data.results
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -22,3 +22,9 @@ export interface ChatMessage {
   sender: 'user' | 'ai';
   timestamp: Date;
 }
+
+export interface NotionBlock {
+  id: string;
+  type: string;
+  [key: string]: any;
+}


### PR DESCRIPTION
## Summary
- add NotionBlock type
- add getPageBlocks helper for Notion API
- create NotionRenderer component to render basic blocks

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfa685a18832d9660e973324ce85b