### PR TITLE
feat: improve NotionRenderer

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,8 @@ export interface ChatMessage {
 
 export interface NotionBlock {
   id: string;
-  type: string;
+  type?: string;
+  object?: string;
+  properties?: Record<string, any>;
   [key: string]: any;
 }


### PR DESCRIPTION
## Summary
- enhance NotionRenderer to support Notion page list responses
- expand `NotionBlock` type to include page attributes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685bfe82d7a4832da6315c2cb8660788