### PR TITLE
Fix Notion CORS

### DIFF
--- a/server.js
+++ b/server.js
@@ -85,6 +85,16 @@ async function callOpenAI(messages, functions = []) {
 }
 
 const server = http.createServer(async (req, res) => {
+  // Basic CORS headers to allow requests from the frontend
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
   if (req.method === 'POST' && req.url === '/api/chat') {
     try {
       const { messages } = await getRequestBody(req);
@@ -140,6 +150,15 @@ const server = http.createServer(async (req, res) => {
       }
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ response: choice.content }));
+    } catch (e) {
+      res.writeHead(500, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ error: e.message }));
+    }
+  } else if (req.method === 'GET' && req.url === '/api/tasks') {
+    try {
+      const tasks = await getTasksFromNotion();
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ tasks }));
     } catch (e) {
       res.writeHead(500, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify({ error: e.message }));

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -1,27 +1,7 @@
 export async function getTasksFromNotion() {
-  const OPENAI_API_KEY = import.meta.env.OPENAI_API_KEY
-  const NOTION_TOKEN = import.meta.env.NOTION_TOKEN
-  console.log(` getTasksFromNotion ~ import.meta.env:`, import.meta.env)
-  const NOTION_DATABASE_ID = import.meta.env.NOTION_DATABASE_ID
-  const res = await fetch(
-    `https://api.notion.com/v1/databases/${NOTION_DATABASE_ID}/query`,
-    {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${NOTION_TOKEN}`,
-        'Content-Type': 'application/json',
-        'Notion-Version': '2022-06-28',
-      },
-      body: JSON.stringify({}),
-    }
-  )
+  const res = await fetch('/api/tasks')
   const data = await res.json()
-  return data.results.map((page) => ({
-    id: page.id,
-    title: page.properties.Name?.title?.[0]?.plain_text || '',
-    status: page.properties.Status?.select?.name || '',
-    priority: page.properties.Priority?.select?.name || '',
-  }))
+  return data.tasks
 }
 
 export async function getPageBlocks(pageId: string) {


### PR DESCRIPTION
## Summary
- add CORS headers on the Node server
- expose `/api/tasks` endpoint to fetch tasks from Notion
- use the new endpoint in the client to avoid direct Notion requests

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js' due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_685da4f850fc832d952da126f4620ecc