### PR TITLE
Fix OpenAI call with empty functions array

### DIFF
--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -14,17 +14,22 @@ export async function callOpenAI(messages, functions = []) {
     };
   });
 
+  const body: any = {
+    model: 'gpt-4o',
+    messages: formattedMessages,
+  }
+
+  if (functions.length > 0) {
+    body.functions = functions
+  }
+
   const res = await fetch('https://api.openai.com/v1/chat/completions', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${OPENAI_API_KEY}`,
     },
-    body: JSON.stringify({
-      model: 'gpt-4o',
-      messages: formattedMessages,
-      functions,
-    }),
+    body: JSON.stringify(body),
   });
 
   return res.json();


### PR DESCRIPTION
## Summary
- avoid sending empty functions array to OpenAI API

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_685e574f4748832d89e4d841a9c75dee