### PR TITLE
Connect frontend to external API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,4 @@ OPENAI_API_KEY=
 NOTION_TOKEN=
 NOTION_DATABASE_ID=
 API_PORT=3001
+VITE_API_BASE_URL=https://visualgpt-ba-aux-gccxwajtmoiyb.herokuapp.com

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -1,7 +1,11 @@
 export async function getTasksFromNotion() {
-  const res = await fetch('/api/tasks')
+  const API_BASE_URL =
+    import.meta.env.VITE_API_BASE_URL ||
+    'https://visualgpt-ba-aux-gccxwajtmoiyb.herokuapp.com'
+
+  const res = await fetch(`${API_BASE_URL}/notion/`)
   const data = await res.json()
-  return data.tasks
+  return data
 }
 
 export async function getPageBlocks(pageId: string) {

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -1,36 +1,19 @@
-export async function callOpenAI(messages, functions = []) {
-  const OPENAI_API_KEY = process.env.VITE_OPENAI_API_KEY;
-  console.log(` callOpenAI ~ process.env:`, process.env);
-  console.log(` callOpenAI ~ OPENAI_API_KEY:`, OPENAI_API_KEY);
+export async function callOpenAI(messages) {
+  const API_BASE_URL =
+    import.meta.env.VITE_API_BASE_URL ||
+    'https://visualgpt-ba-aux-gccxwajtmoiyb.herokuapp.com';
 
-  // Ensure messages are in OpenAI chat completion format
-  const formattedMessages = messages.map((m) => {
-    if (m.role && m.content) {
-      return m;
-    }
-    return {
-      role: m.sender === 'user' ? 'user' : 'assistant',
-      content: m.text,
-    };
-  });
+  const last = messages[messages.length - 1];
+  const prompt = last.content ?? last.text ?? '';
 
-  const body: any = {
-    model: 'gpt-4o',
-    messages: formattedMessages,
-  }
-
-  if (functions.length > 0) {
-    body.functions = functions
-  }
-
-  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+  const res = await fetch(`${API_BASE_URL}/chat`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      Authorization: `Bearer ${OPENAI_API_KEY}`,
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify({ prompt }),
   });
 
-  return res.json();
+  const data = await res.json();
+  return data.answer ?? data;
 }


### PR DESCRIPTION
## Summary
- configure `VITE_API_BASE_URL` for external backend
- update OpenAI and Notion services to use the new API URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860471882d4832d8efcd8d32b8145c3