### PR TITLE
Integrate Notion API and OpenAI service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # Rename this file to .env and fill in your credentials
-OPENAI_API_KEY=
+VITE_OPENAI_API_KEY=
+VITE_OPENAI_API_URL=https://api.openai.com/v1/chat/completions
 NOTION_TOKEN=
 NOTION_DATABASE_ID=
 API_PORT=3001

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ This project includes a simple Node server that connects with the Notion and Ope
 Copy `.env.example` to `.env` and provide your credentials:
 
 ```
-OPENAI_API_KEY=<your openai key>
+VITE_OPENAI_API_KEY=<your openai key>
 NOTION_TOKEN=<your notion token>
 NOTION_DATABASE_ID=<your database id>
 ```

--- a/src/components/FloatingChat.tsx
+++ b/src/components/FloatingChat.tsx
@@ -5,7 +5,7 @@ import { Input } from '@/components/ui/input'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { ChatMessage } from '@/types'
 import { cn } from '@/lib/utils'
-import { callOpenAI } from '@/services/openai'
+import { openAIService } from '@/services/openai'
 
 const initialMessages: ChatMessage[] = [
   {
@@ -38,7 +38,7 @@ export const FloatingChat = () => {
 
     console.log(` handleSendMessage ~ updatedMessages:`, updatedMessages)
     try {
-      const response = await callOpenAI(updatedMessages)
+      const response = await openAIService.chat(updatedMessages)
       if (response.error) {
         console.error('Error from OpenAI:', response.error)
         throw new Error(response.error.message || 'Error desconocido')

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -1,25 +1,49 @@
-export async function getTasksFromNotion() {
-  const API_BASE_URL =
-    import.meta.env.VITE_API_BASE_URL ||
-    'https://visualgpt-ba-aux-gccxwajtmoiyb.herokuapp.com'
+export class NotionService {
+  private token: string
+  private version = '2022-06-28'
 
-  const res = await fetch(`${API_BASE_URL}/notion/`)
-  const data = await res.json()
-  return data
-}
+  constructor() {
+    this.token = import.meta.env.NOTION_TOKEN || ''
+  }
 
-export async function getPageBlocks(pageId: string) {
-  const NOTION_TOKEN = import.meta.env.NOTION_TOKEN
-  const res = await fetch(
-    `https://api.notion.com/v1/blocks/${pageId}/children`,
-    {
-      headers: {
-        Authorization: `Bearer ${NOTION_TOKEN}`,
-        'Content-Type': 'application/json',
-        'Notion-Version': '2022-06-28',
-      },
+  private get headers() {
+    return {
+      Authorization: `Bearer ${this.token}`,
+      'Content-Type': 'application/json',
+      'Notion-Version': this.version,
     }
-  )
-  const data = await res.json()
-  return data.results
+  }
+
+  async getDatabases() {
+    const res = await fetch('https://api.notion.com/v1/search', {
+      method: 'POST',
+      headers: this.headers,
+      body: JSON.stringify({ filter: { property: 'object', value: 'database' } }),
+    })
+    const data = await res.json()
+    return data.results
+  }
+
+  async getDatabasePages(databaseId: string) {
+    const res = await fetch(
+      `https://api.notion.com/v1/databases/${databaseId}/query`,
+      {
+        method: 'POST',
+        headers: this.headers,
+        body: JSON.stringify({}),
+      }
+    )
+    return res.json()
+  }
+
+  async getPageBlocks(pageId: string) {
+    const res = await fetch(
+      `https://api.notion.com/v1/blocks/${pageId}/children`,
+      { headers: this.headers }
+    )
+    const data = await res.json()
+    return data.results
+  }
 }
+
+export const notionService = new NotionService()


### PR DESCRIPTION
## Summary
- refactor `openai` service into a class calling OpenAI API directly
- refactor Notion service into a class with database helpers
- use the new services in the chat component and index page
- load Notion databases into tabs and render selected database pages
- update environment variables and docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604aa56a98832db268eeaca7fa90b1