### PR TITLE
Connect to hosted API

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Copy `.env.example` to `.env` and provide your credentials:
 VITE_OPENAI_API_KEY=<your openai key>
 NOTION_TOKEN=<your notion token>
 NOTION_DATABASE_ID=<your database id>
+VITE_API_BASE_URL=https://visualgpt-ba-aux-gccxwajtmoiyb.herokuapp.com
 ```
 
 Start the API server with:
@@ -88,5 +89,6 @@ Start the API server with:
 ```
 npm run server
 ```
-
-The frontend will send chat messages to `/api/chat` to fetch or create tasks using these APIs.
+The frontend uses `VITE_API_BASE_URL` to communicate with the backend. By default it
+points to the hosted instance at `https://visualgpt-ba-aux-gccxwajtmoiyb.herokuapp.com`.
+If you prefer running the local Node server, update this variable accordingly.

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -1,9 +1,11 @@
 export class NotionService {
   private token: string
   private version = '2022-06-28'
+  private apiBaseUrl: string | null
 
   constructor() {
     this.token = import.meta.env.NOTION_TOKEN || ''
+    this.apiBaseUrl = import.meta.env.VITE_API_BASE_URL || null
   }
 
   private get headers() {
@@ -15,6 +17,11 @@ export class NotionService {
   }
 
   async getDatabases() {
+    if (this.apiBaseUrl) {
+      const res = await fetch(`${this.apiBaseUrl}/notion/`)
+      const data = await res.json()
+      return data.results
+    }
     const res = await fetch('https://api.notion.com/v1/search', {
       method: 'POST',
       headers: this.headers,
@@ -25,6 +32,10 @@ export class NotionService {
   }
 
   async getDatabasePages(databaseId: string) {
+    if (this.apiBaseUrl) {
+      const res = await fetch(`${this.apiBaseUrl}/notion/databases/${databaseId}`)
+      return res.json()
+    }
     const res = await fetch(
       `https://api.notion.com/v1/databases/${databaseId}/query`,
       {
@@ -37,6 +48,10 @@ export class NotionService {
   }
 
   async getPageBlocks(pageId: string) {
+    if (this.apiBaseUrl) {
+      const res = await fetch(`${this.apiBaseUrl}/notion/databases/${pageId}`)
+      return res.json()
+    }
     const res = await fetch(
       `https://api.notion.com/v1/blocks/${pageId}/children`,
       { headers: this.headers }

--- a/src/services/openai.ts
+++ b/src/services/openai.ts
@@ -3,15 +3,28 @@ import type { ChatMessage } from '@/types'
 export class OpenAIService {
   private apiKey: string
   private apiUrl: string
+  private apiBaseUrl: string | null
 
   constructor() {
     this.apiKey = import.meta.env.VITE_OPENAI_API_KEY || ''
     this.apiUrl =
       import.meta.env.VITE_OPENAI_API_URL ||
       'https://api.openai.com/v1/chat/completions'
+    this.apiBaseUrl = import.meta.env.VITE_API_BASE_URL || null
   }
 
   async chat(messages: ChatMessage[]) {
+    if (this.apiBaseUrl) {
+      const last = messages[messages.length - 1]
+      const res = await fetch(`${this.apiBaseUrl}/chat`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ prompt: last.text }),
+      })
+      const data = await res.json()
+      return data.answer
+    }
+
     const formatted = messages.map((m) => ({
       role: m.sender === 'user' ? 'user' : 'assistant',
       content: m.text,


### PR DESCRIPTION
## Summary
- use API_BASE_URL for OpenAI and Notion services
- document API_BASE_URL in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68604c79299c832d8550ecd6499ff963