### PR TITLE
Update Notion integration to fetch pages

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,6 @@
 VITE_OPENAI_API_KEY=
 VITE_OPENAI_API_URL=https://api.openai.com/v1/chat/completions
 NOTION_TOKEN=
-NOTION_DATABASE_ID=
+NOTION_PAGE_ID=
 API_PORT=3001
 VITE_API_BASE_URL=https://visualgpt-ba-aux-gccxwajtmoiyb.herokuapp.com

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Copy `.env.example` to `.env` and provide your credentials:
 ```
 VITE_OPENAI_API_KEY=<your openai key>
 NOTION_TOKEN=<your notion token>
-NOTION_DATABASE_ID=<your database id>
+NOTION_PAGE_ID=<your page id>
 VITE_API_BASE_URL=https://visualgpt-ba-aux-gccxwajtmoiyb.herokuapp.com
 ```
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -116,11 +116,11 @@ const Index = () => {
   useEffect(() => {
     const fetchBoards = async () => {
       try {
-        const databases = await notionService.getDatabases()
-        if (databases.length) {
-          const boardsFromNotion = databases.map((db, idx) => ({
-            id: db.id,
-            name: db.title?.[0]?.plain_text || `Database ${idx + 1}`,
+        const pages = await notionService.getPages()
+        if (pages.length) {
+          const boardsFromNotion = pages.map((pg, idx) => ({
+            id: pg.id,
+            name: pg.properties?.Name?.title?.[0]?.plain_text || `Page ${idx + 1}`,
             color: initialBoards[idx % initialBoards.length].color,
             tasks: [],
           }))
@@ -139,8 +139,8 @@ const Index = () => {
   useEffect(() => {
     const fetchPages = async () => {
       try {
-        const data = await notionService.getDatabasePages(selectedBoardId)
-        setNotionData(data)
+        const data = await notionService.getPage(selectedBoardId)
+        setNotionData({ object: 'list', results: [data] } as any)
       } catch (e) {
         console.error('Error fetching pages', e)
       }

--- a/src/services/notion.ts
+++ b/src/services/notion.ts
@@ -16,7 +16,7 @@ export class NotionService {
     }
   }
 
-  async getDatabases() {
+  async getPages() {
     if (this.apiBaseUrl) {
       const res = await fetch(`${this.apiBaseUrl}/notion/`)
       const data = await res.json()
@@ -25,31 +25,26 @@ export class NotionService {
     const res = await fetch('https://api.notion.com/v1/search', {
       method: 'POST',
       headers: this.headers,
-      body: JSON.stringify({ filter: { property: 'object', value: 'database' } }),
+      body: JSON.stringify({ filter: { property: 'object', value: 'page' } }),
     })
     const data = await res.json()
     return data.results
   }
 
-  async getDatabasePages(databaseId: string) {
+  async getPage(pageId: string) {
     if (this.apiBaseUrl) {
-      const res = await fetch(`${this.apiBaseUrl}/notion/databases/${databaseId}`)
+      const res = await fetch(`${this.apiBaseUrl}/notion/${pageId}`)
       return res.json()
     }
-    const res = await fetch(
-      `https://api.notion.com/v1/databases/${databaseId}/query`,
-      {
-        method: 'POST',
-        headers: this.headers,
-        body: JSON.stringify({}),
-      }
-    )
+    const res = await fetch(`https://api.notion.com/v1/pages/${pageId}`, {
+      headers: this.headers,
+    })
     return res.json()
   }
 
   async getPageBlocks(pageId: string) {
     if (this.apiBaseUrl) {
-      const res = await fetch(`${this.apiBaseUrl}/notion/databases/${pageId}`)
+      const res = await fetch(`${this.apiBaseUrl}/notion/${pageId}/blocks`)
       return res.json()
     }
     const res = await fetch(


### PR DESCRIPTION
## Summary
- switch Notion environment variable to `NOTION_PAGE_ID`
- update example env and README
- adjust server to read/write page blocks
- update Notion service to fetch pages
- refactor Index page to use page data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6860560e2e68832dba5f6b9d8432221b